### PR TITLE
Fix floating point number imprecision on withdraw and sidebar menu padding issues

### DIFF
--- a/assets/themes/coinage/sass/new/_sidebar.scss
+++ b/assets/themes/coinage/sass/new/_sidebar.scss
@@ -11,7 +11,8 @@
         color: #607381;
         font-size: 15px;
         font-weight: 600;
-        padding: 12px 18px;
+        padding: 12px 16px;
+        white-space: nowrap;
 
         i {
           margin-right: 10px
@@ -35,7 +36,6 @@
 
             &:hover {
                 background: #f2f7fa;
-                padding-left: 22px!important;
             }
 
             &:focus {
@@ -49,7 +49,6 @@
       > a {
         background: $component-active-bg;
         color: #fff!important;
-        padding-left: 22px!important;
         &:hover {
             background: $component-active-bg;
         }

--- a/jsdev/bitex/app/blinktrade.js
+++ b/jsdev/bitex/app/blinktrade.js
@@ -2233,7 +2233,7 @@ bitex.app.BlinkTrade.prototype.showWithdrawalDialog = function(currency, opt_pre
             e.preventDefault();
             return;
           }
-          amount = new bitex.primitives.Price(amount * 1e8,
+          amount = new bitex.primitives.Price((amount * 1e8).toFixed(0),
                                               this.getCurrencyPip(withdraw_data['Currency'])).floor();
 
           var pos = [0];

--- a/jsdev/bitex/ui/advanced_order_entry.js
+++ b/jsdev/bitex/ui/advanced_order_entry.js
@@ -488,7 +488,7 @@ bitex.ui.AdvancedOrderEntry.prototype.getAmount = function(){
   if (pos[0] != inputValue.length || isNaN(value) || value <= 0 ) {
     return 0;
   }
-  return parseInt(value * this.factor_amount_, 10);
+  return parseInt((value * this.factor_amount_).toFixed(0), 10);
 };
 
 /**

--- a/jsdev/bitex/ui/simple_order_entry.js
+++ b/jsdev/bitex/ui/simple_order_entry.js
@@ -585,9 +585,9 @@ bitex.ui.SimpleOrderEntry.prototype.getAmount = function(){
       return 0;
     }
 
-    return parseInt(value * this.factor_amount_, 10);
+    return parseInt((value * this.factor_amount_).toFixed(0), 10);
   } else {
-    return this.getModel().amount;
+    return parseInt(this.getModel().amount.toFixed(0));
   }
 };
 


### PR DESCRIPTION
* This avoids some issues when numbers add up like e.g.: 0.0048 * 1e8 = 479999.99999999994